### PR TITLE
Fix weight update logic

### DIFF
--- a/examples/xor.nim
+++ b/examples/xor.nim
@@ -11,9 +11,9 @@ proc genXorData(n: int): tuple[input: Matrix[float], output: Matrix[float]] =
 
 when isMainModule:
   var network = newNNBuilder()
-    .add(newDense(2, 3))
+    .add(newDense(2, 10))
     .add(newSigmoid())
-    .add(newDense(3, 1))
+    .add(newDense(10, 1))
     .add(newSigmoid())
     .minimize(newBinaryCrossEntropy())
     .optimize(newSGD(0.1))

--- a/src/nn/network.nim
+++ b/src/nn/network.nim
@@ -93,8 +93,8 @@ proc runBatch(self: var Network, input, expected: Matrix[NNFloat], options: Opti
     var
       (idx, grad) = (item.idx, item.grad)
       links = Links(self.layers[idx])
-      weights = links.weights.transform((val: NNFloat) => val / input.row.NNFloat)
-    self.optimizer.update(weights, grad)
+      normalizedGrad = grad.transform((val: NNFloat) => val / input.row.NNFloat)
+    self.optimizer.update(links.weights, normalizedGrad)
   let loss = self.lossFromProbs(outputs.last, expected)
   let (hit, miss) = self.hitMissCntFromProbs(outputs.last, expected)
   result = (hit, miss, loss)
@@ -139,4 +139,3 @@ proc checkGradient*(self: var Network, input, expected: Matrix[NNFloat], grads: 
         links.weights[i, j] = x
         let numericDiff = (fx2 - fx1) / (2.0 * h)
         assert abs(grad[i, j] -  numericDiff) <= 1e-6, $grad[i, j] & " " & $numericDiff
-


### PR DESCRIPTION
確認してみたら`weights`の更新が怪しいことになってたみたい！

あと、僕の実装例でもそうだけど、xorの隠れそうの次元が3だと表現力が足りなくて初期値によって線形関数的なものしか学習してくれないっぽい。10次元ぐらいにしておくと解決する。